### PR TITLE
Replaced regex with actual VLQ parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,28 +4,41 @@
  * MIT 
  * Author Joe Bruno <joevbruno@me.com>
  */
-function VSFixSourceMapsPlugin() {}
+var vlq = require('vlq');
+
+function VSFixSourceMapsPlugin() { }
 module.exports = VSFixSourceMapsPlugin;
 
-VSFixSourceMapsPlugin.prototype.apply = function(compiler) {
-  var mapRegEx = new RegExp('.map$');
-  compiler.plugin("compilation", function(compilation) {
-    compilation.plugin("after-optimize-assets", function(assets) {
-      var modifiedAssets = Object.keys(assets).map(function(asset) {
-        if (mapRegEx.test(asset)) {
-          var assetSourceMaps = assets[asset]._value;
-          var parsedSourceMaps = JSON.parse(assetSourceMaps);
-          var regToFixSourceMaps = new RegExp(',\s*[^\s\";]{1,3}?(;|\")', 'g');
-          var fixedMaps = parsedSourceMaps.mappings.replace(regToFixSourceMaps, ';');
-          parsedSourceMaps.mappings = fixedMaps;
-          var reSerializedSourceMaps = JSON.stringify(parsedSourceMaps);
-          assets[asset]._value = reSerializedSourceMaps;
-          return assets;
-        }
-        return asset; 
-      });
-      return modifiedAssets;
+VSFixSourceMapsPlugin.prototype.apply = function (compiler) {
+    var mapRegEx = new RegExp('.map$');
+    compiler.plugin("compilation", function (compilation) {
+        compilation.plugin("after-optimize-assets", function (assets) {
+            var modifiedAssets = Object.keys(assets).map(function (asset) {
+                if (mapRegEx.test(asset)) {
+                    var assetSourceMaps = assets[asset]._value;
+                    var parsedSourceMaps = JSON.parse(assetSourceMaps);
+                    parsedSourceMaps.mappings = parsedSourceMaps.mappings.split(";").map(processMappingLine).join(";");
+                    var reSerializedSourceMaps = JSON.stringify(parsedSourceMaps);
+                    assets[asset]._value = reSerializedSourceMaps;
+                    return assets;
+                }
+                return asset;
+            });
+            return modifiedAssets;
+        });
     });
-  });
+};
+
+function processMappingLine(line) {
+    if (line) {
+        var lastComaIdx = line.lastIndexOf(",");
+        var lastSegment = line.substr(lastComaIdx + 1);
+        // remove last segment if it contains 1 integer
+        // (indicating that there's no corresponding line in the source)
+        if (lastSegment && vlq.decode(lastSegment).length === 1) {
+            return line.substr(0, lastComaIdx); // (0,-1) yields ""
+        }
+    }
+    return line;
 };
 

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "bugs": {
     "url": "https://github.com/joevbruno/vs-fix-sourcemaps/issues"
   },
-  "homepage": "https://github.com/joevbruno/vs-fix-sourcemaps#readme"
+  "homepage": "https://github.com/joevbruno/vs-fix-sourcemaps#readme",
+  "dependencies": {
+    "vlq": "^0.2.1"
+  }
 }


### PR DESCRIPTION
Original version of the plugin didn't work in my project. 

For development speed I replaced regex matching with actual parsing of mappings. I remove last segment in a line if it contains only one vlq-encoded integer meaning that it doesn't contain any mapping to source files and potentially can cause problems with VS.

It performs fast enough for me so I didn't bother optimizing it. But it should be very easy to drop vlq parsing and go with regex to check that last segment is `/[g-z0-9+\/]+[A-Za-f]/` so feel free to reject the PR it and adjust the regex instead if you don't like the performance or external dependency.
